### PR TITLE
Reply to WebSocket ping frames

### DIFF
--- a/Sources/MQTTNIO/Handlers/WebSocketHandler.swift
+++ b/Sources/MQTTNIO/Handlers/WebSocketHandler.swift
@@ -77,6 +77,9 @@ final class WebSocketHandler: ChannelDuplexHandler {
             frameSequence.append(frame.data)
             self.frameSequence = frameSequence
             
+        case .ping:
+            send(context: context, buffer: frame.data, opcode: .pong)
+            
         case .connectionClose:
             isClosed = true
             context.close(promise: nil)


### PR DESCRIPTION
This fixes WebSocket connections to Mosquitto brokers disconnecting every 5 minutes due to the server not receiving any response to WebSocket ping frames. Mosquitto uses libwebsockets which defaults to sending a ping frame every 5 minutes with a 10 second timeout.