### PR TITLE
Prevent inflight array index crash and precondition failure on password buffer

### DIFF
--- a/Sources/MQTTNIO/Packet/Types/MQTTPacket+Connect.swift
+++ b/Sources/MQTTNIO/Packet/Types/MQTTPacket+Connect.swift
@@ -164,7 +164,7 @@ extension MQTTPacket {
                 flags.insert(.containsUsername)
                 try buffer.writeMQTTString(credentials.username, "Username")
                 
-                if var password = credentials.password, password.readableBytes > 0 {
+                if var password = credentials.password {
                     flags.insert(.containsPassword)
                     try buffer.writeMQTTDataWithLength(&password, "Password")
                 }

--- a/Sources/MQTTNIO/Packet/Types/MQTTPacket+Connect.swift
+++ b/Sources/MQTTNIO/Packet/Types/MQTTPacket+Connect.swift
@@ -164,7 +164,7 @@ extension MQTTPacket {
                 flags.insert(.containsUsername)
                 try buffer.writeMQTTString(credentials.username, "Username")
                 
-                if var password = credentials.password {
+                if var password = credentials.password, password.readableBytes > 0 {
                     flags.insert(.containsPassword)
                     try buffer.writeMQTTDataWithLength(&password, "Password")
                 }

--- a/Sources/MQTTNIO/Utilities/ByteBuffer+Extensions.swift
+++ b/Sources/MQTTNIO/Utilities/ByteBuffer+Extensions.swift
@@ -111,11 +111,12 @@ extension ByteBuffer {
     }
     
     mutating func writeMQTTDataWithLength(_ payload: inout ByteBuffer, _ errorVariableName: String) throws {
-        
+        reserveCapacity(minimumWritableBytes: 2 + payload.readableBytes)
+
         // Leave room for length
         let lengthIndex = writerIndex
         moveWriterIndex(forwardBy: 2)
-        
+
         let length = writeBuffer(&payload)
         guard length <= UInt16.max else {
             throw MQTTValueError.valueTooLarge(errorVariableName)


### PR DESCRIPTION
### Summary

This pull request includes two independent but related fixes:

1. **Fix index out-of-range crash in `MQTTRequestHandler.channelRead`**
   - Replaces mutation of `entriesInflight` during iteration with a `compactMap` to safely remove completed entries without corrupting indices.

2. **Fix potential `preconditionFailure` when writing CONNECT packet password**
   - Ensures the `password` buffer has a valid reader index and is not empty before passing to `writeMQTTDataWithLength`

Thank you.

Tobias